### PR TITLE
Increase NOFILE and NPROC limits

### DIFF
--- a/debian/lxd.service
+++ b/debian/lxd.service
@@ -9,7 +9,8 @@ KillMode=process
 TimeoutStopSec=40
 KillSignal=SIGPWR
 Restart=on-failure
-LimitNOFILE=65536
+LimitNOFILE=1048576
+LimitNPROC=1048576
 
 [Install]
 Also=lxd-unix.socket lxd-tcp.socket


### PR DESCRIPTION
Increasing the max number of files and processes. It seems containers inherit these max values.

Otherwise, the following is not possible

```
adduser foo
echo "foo             hard    nproc           32768" >> /etc/security/limits.conf
su - foo
```

Without the change, su will fail with the error "could not open session" because it is trying to increase nproc above the max.

Signed-off-by: Ragnar Rova ragnar.rova@gmail.com
